### PR TITLE
add CMakeLists.txt for linear and deformable targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 2.8)
+project(deedsBCV)
+
+include_directories("./src/")
+
+SET(CMAKE_CXX_FLAGS  "-std=c++11 -O3 -fopenmp -mavx2 -msse4.2")
+
+add_executable(linear src/linearBCV.cpp)
+target_link_libraries(linear -lz)
+
+add_executable(deeds src/deedsBCV0.cpp)
+target_link_libraries(deeds -lz)


### PR DESCRIPTION
First of all, thank you for you incredible work.
We've started incorporating it in the [Slicer](https://www.slicer.org/) ecosystem: we're building an extension to enable registration of volumes within the Slicer application. We need a `CMakeLists.txt` to build the extension cross-platform, therefore we created this pull request.